### PR TITLE
Add previous-message support for v2g command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ A comprehensive suite of tools for downloading media and converting videos to GI
 
 ### 3. Direct FFmpeg GIF (`<p>v2g`)
  - Convert to GIF: `<p>v2g <url or attachment> [-fps=15] [-scale=480:-1] [-time=0-30] [-optimize] [-720p] [-speed=<factor>]`
-- Configure: `<p>v2g url|path|debug|persistent|status`
+   - If called without arguments, the command checks the previous message for a video attachment or direct link.
+ - Configure: `<p>v2g url|path|debug|persistent|status`
 
 ## Parameters
 

--- a/unified_cobalt.py
+++ b/unified_cobalt.py
@@ -1143,21 +1143,45 @@ def unified_cobalt_script():
         if args.lower().startswith(("url ", "path ", "debug", "persistent", "lb")):
             await handle_config_command(ctx, args, "v2g")
             return
-        
-        # Handle conversion request
+
+        video_path = None
+        parsed_args = None
+
+        # If no args, attempt to use the previous message
         if not args:
-            await ctx.send("❌ Please provide a URL or attach a video file.")
-            return
-        
+            history = [m async for m in ctx.channel.history(limit=2)]
+            if len(history) < 2:
+                return
+            prev_msg = history[1]
+            if prev_msg.attachments:
+                attachment = prev_msg.attachments[0]
+                if not any(attachment.filename.lower().endswith(ext) for ext in ['.mp4', '.mov', '.avi', '.mkv', '.webm']):
+                    return
+                msg = await ctx.send("⏳ Downloading attachment from previous message...")
+                try:
+                    video_path = await download_file(attachment.url, attachment.filename)
+                    parsed_args = parse_v2g_args("")
+                except Exception as e:
+                    await msg.edit(content=f"❌ Error downloading attachment: {str(e)}")
+                    return
+            else:
+                match = re.search(r'https?://\S+', prev_msg.content)
+                if match and any(match.group(0).split('?')[0].lower().endswith(ext) for ext in ['.mp4', '.mov', '.avi', '.mkv', '.webm']):
+                    args = match.group(0)
+                else:
+                    return
+
         # Validate that the first word is a URL before parsing
-        first_word = args.split()[0].lower()
+        first_word = args.split()[0].lower() if args else ""
         if first_word in ["url", "path", "debug", "persistent", "lb", "status"]:
             await handle_config_command(ctx, args, "v2g")
             return
-        
+
+        if parsed_args is None:
+            parsed_args = parse_v2g_args(args)
+
         # Check for attachment
-        video_path = None
-        if ctx.message.attachments:
+        if video_path is None and ctx.message.attachments:
             attachment = ctx.message.attachments[0]
             if not any(attachment.filename.lower().endswith(ext) for ext in ['.mp4', '.mov', '.avi', '.mkv', '.webm']):
                 await ctx.send("❌ Please attach a video file (mp4, mov, avi, mkv, webm)")
@@ -1169,7 +1193,7 @@ def unified_cobalt_script():
             except Exception as e:
                 await msg.edit(content=f"❌ Error downloading attachment: {str(e)}")
                 return
-        else:
+        elif video_path is None:
             # Handle URL
             parsed_args = parse_v2g_args(args)
             url_to_download = parsed_args["url"]
@@ -1307,4 +1331,4 @@ def unified_cobalt_script():
             await msg.edit(content=user_msg)
 
 # Initialize the script
-unified_cobalt_script() 
+unified_cobalt_script()


### PR DESCRIPTION
## Summary
- allow calling `v2g` with no arguments to convert the video from the previous message
- document the new behaviour in README

## Testing
- `python -m py_compile unified_cobalt.py "Unified Cobalt - NITRO Testing.py"`

------
https://chatgpt.com/codex/tasks/task_e_684407ba52388320a1621a245f2e6ace