### PR TITLE
Fix GIF speed in NITRO script

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ A comprehensive suite of tools for downloading media and converting videos to GI
  - Time: `-time=<start>-<end>` (in seconds, decimals allowed)
  - Optimize: `-optimize` (reduces file size)
  - Loop: `-loop=<number>` (default: 0, -1 for infinite)
- - Dither: `-dither=<method>` (default: bayer:bayer_scale=5)
- - Colors: `-colors=<number>` (default: 256)
- - Speed: `-speed=<factor>` (default: 1.0, e.g. 0.5 for half speed, 2.0 for double speed)
+- Dither: `-dither=<method>` (default: bayer:bayer_scale=5)
+- Colors: `-colors=<number>` (default: 256)
+- Speed: `-speed=<factor>` (default: 1.0, e.g. 0.5 for half speed, 2.0 for double speed)
+   - Speed adjustments are applied with `gifsicle`, ensuring the GIF loops cleanly.
 
 ## Examples
 

--- a/Unified Cobalt - NITRO Testing.py
+++ b/Unified Cobalt - NITRO Testing.py
@@ -108,6 +108,7 @@ def unified_cobalt_script():
     - Dither: -dither=<method> (default: bayer:bayer_scale=5)
     - Colors: -colors=<number> (default: 256)
     - Speed: -speed=<factor> (default: 1.0, e.g. 0.5 for half speed, 2.0 for double speed)
+      - Speed adjustments are applied with gifsicle, ensuring the GIF loops cleanly.
     
     EXAMPLES:
     1. Download a video in 720p quality:
@@ -738,20 +739,14 @@ def unified_cobalt_script():
         if not os.path.exists(palette_path):
             raise Exception(f"Failed to generate palette image")
         
-        # Convert to GIF with speed modification if specified
+        # Convert to GIF
         vf_parts = []
-        
-        # Add basic filters
+
+        # Ensure consistent frame rate and scaling
+        vf_parts.append(f"fps={fps}")
         vf_parts.append(f"scale={scale}:flags=lanczos")
-        
-        # Handle speed changes
-        if speed != 1.0:
-            # First apply speed change
-            vf_parts.append(f"setpts={1/speed}*PTS")
-            # Then force consistent frame rate
-            vf_parts.append(f"fps={fps}")
-        
-        # Add palette use with dithering for better quality
+
+        # Palette generation and usage
         vf_parts.append("split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse=dither=bayer:bayer_scale=5")
         
         # Join filters with commas
@@ -776,6 +771,16 @@ def unified_cobalt_script():
         gif_path = os.path.join(output_dir, gif_filename)
         if not os.path.exists(gif_path):
             raise Exception(f"gif file not found")
+
+        # Adjust playback speed by modifying frame delay
+        if speed != 1.0:
+            base_delay = 100 / fps
+            new_delay = max(1, int(round(base_delay / speed)))
+            delay_cmd = (
+                f'docker run --rm -v "{output_dir}:/src" dylanninin/giflossy '
+                f'gifsicle --batch --no-warnings --delay={new_delay} /src/{gif_filename}'
+            )
+            await run_docker_cmd(delay_cmd)
         
         # Check initial size
         initial_size = os.path.getsize(gif_path) / (1024 * 1024)
@@ -1428,10 +1433,6 @@ def unified_cobalt_script():
         vf_parts.append(f"fps={parsed_args['fps']}")
         vf_parts.append(f"scale={parsed_args['scale']}:flags=lanczos")
         
-        # Add speed modification if specified
-        if parsed_args["speed"] != 1.0:
-            vf_parts.append(f"setpts={1/parsed_args['speed']}*PTS")
-        
         # Palette generation
         if parsed_args["optimize"]:
             palette_params = f"palettegen=max_colors={parsed_args['colors']}:reserve_transparent=1"
@@ -1459,7 +1460,17 @@ def unified_cobalt_script():
             
             if not os.path.exists(gif_path):
                 raise Exception("GIF file not found")
-            
+
+            # Adjust playback speed by modifying frame delay
+            if parsed_args["speed"] != 1.0:
+                base_delay = 100 / parsed_args["fps"]
+                new_delay = max(1, int(round(base_delay / parsed_args["speed"])))
+                delay_cmd = (
+                    f'docker run --rm -v "{output_dir}:/src" dylanninin/giflossy '
+                    f'gifsicle --batch --no-warnings --delay={new_delay} /src/{gif_filename}'
+                )
+                await run_docker_cmd(delay_cmd)
+
             # Check size
             final_size = os.path.getsize(gif_path) / (1024 * 1024)
             size_threshold = float(getConfigData().get(LITTERBOX_SIZE_THRESHOLD_MB_KEY, 50))


### PR DESCRIPTION
## Summary
- apply gifsicle-based speed adjustment to `Unified Cobalt - NITRO Testing.py`
- update direct FFmpeg path to remove `setpts` filter
- document new speed handling in script comments

## Testing
- `python -m py_compile 'Unified Cobalt - NITRO Testing.py'`
- `python -m py_compile unified_cobalt.py`

------
https://chatgpt.com/codex/tasks/task_e_6848f6a37df8832094c7c260441248ef